### PR TITLE
move jaxrsIT's schemaFirst swagger api to demo-schema

### DIFF
--- a/demo/demo-schema/src/main/resources/microservices/jaxrs/schemaFirst.yaml
+++ b/demo/demo-schema/src/main/resources/microservices/jaxrs/schemaFirst.yaml
@@ -24,7 +24,7 @@ paths:
           format: int32
       responses:
         200:
-          description: add numer
+          description: add number
           schema:
             type: integer
             format: int32


### PR DESCRIPTION
The swagger api declarations of schemaFirst and compute store in two different paths:
"integration-tests/jaxrs-tests/src/test/resources/microservices/jaxrs" and
"demo/demo-schema/src/main/resources/microservices/jaxrs".
Is it a better idea to place it together under the demo-schema module like the pojo did?
