### PR TITLE
line 70：“qpsLimit = null” -> "return null"

### DIFF
--- a/handlers/handler-flowcontrol-qps/src/main/java/io/servicecomb/qps/ProviderQpsControllerManager.java
+++ b/handlers/handler-flowcontrol-qps/src/main/java/io/servicecomb/qps/ProviderQpsControllerManager.java
@@ -67,7 +67,7 @@ public class ProviderQpsControllerManager
 
   private QpsController initQpsLimit(String key, Integer qpsLimit) {
     if (qpsLimit == null) {
-      qpsLimit = null;
+      return null;
     }
 
     LOGGER.info("qpsLimit of {} init as {}", key, qpsLimit);


### PR DESCRIPTION
判断条件中 qpsLimit 的值已经为 "null"，若此处不反回跳出函数，执行至第76行qpsControllerMap.put赋值后，导致null 值的默认值转化。