### PR TITLE
【JAV-281】cann't reconnect to SC at retry thread.

### DIFF
--- a/core/src/main/java/io/servicecomb/core/definition/schema/ConsumerSchemaFactory.java
+++ b/core/src/main/java/io/servicecomb/core/definition/schema/ConsumerSchemaFactory.java
@@ -77,10 +77,12 @@ public class ConsumerSchemaFactory extends AbstractSchemaFactory<ConsumerSchemaC
             Set<String> schemaIds = findLocalSchemas(microserviceMeta);
             Microservice microservice =
                 findMicroservice(microserviceMeta, microserviceVersionRule);
-            if (microservice != null) {
-                schemaIds.addAll(microservice.getSchemas());
-            }
-
+            if (microservice == null) {
+                throw new Error(
+                        String.format("can not get microservice from service center, name=%s",
+                                microserviceName));
+            }           
+            schemaIds.addAll(microservice.getSchemas());
             getOrCreateConsumerSchema(microserviceMeta, schemaIds, microservice);
 
             microserviceMetaManager.register(microserviceName, microserviceMeta);
@@ -163,13 +165,6 @@ public class ConsumerSchemaFactory extends AbstractSchemaFactory<ConsumerSchemaC
         Swagger swagger = super.loadSwagger(context);
         if (swagger != null) {
             return swagger;
-        }
-
-        if (context.getMicroservice() == null) {
-            throw new Error(
-                    String.format("no schema in local, and can not get microservice from service center, %s:%s",
-                            context.getMicroserviceName(),
-                            context.getSchemaId()));
         }
 
         ServiceRegistryClient client = RegistryUtils.getServiceRegistryClient();


### PR DESCRIPTION
if SDK cann't connect to SC successfully at the fist time when SDK initialize ConsumerProviderManager , without throw exception at first time the retry thread never try to connect to SC any more, because some properties have been initialized.