### PR TITLE
Consumer init optimize

### DIFF
--- a/demo/demo-pojo/pojo-client/src/main/resources/META-INF/spring/pojo.client.bean.xml
+++ b/demo/demo-pojo/pojo-client/src/main/resources/META-INF/spring/pojo.client.bean.xml
@@ -27,10 +27,6 @@
 	<cse:rpc-reference id="smartcare" microservice-name="pojo"
 		schema-id="smartcare"></cse:rpc-reference>
 
-
-	<cse:rpc-reference id="helloworld.Greeter"
-		microservice-name="pojo" schema-id="helloworld.Greeter"></cse:rpc-reference>
-
 	<cse:rpc-reference id="server" microservice-name="pojo"
 		schema-id="server" interface="io.servicecomb.demo.server.Test"></cse:rpc-reference>
 		

--- a/demo/demo-spring-boot-transport/demo-spring-boot-pojo-client/src/main/resources/META-INF/spring/pojo.client.bean.xml
+++ b/demo/demo-spring-boot-transport/demo-spring-boot-pojo-client/src/main/resources/META-INF/spring/pojo.client.bean.xml
@@ -24,9 +24,6 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
 		http://www.huawei.com/schema/paas/cse/rpc classpath:META-INF/spring/spring-paas-cse-rpc.xsd">
 
-	<cse:rpc-reference id="helloworld.Greeter"
-		microservice-name="pojo" schema-id="helloworld.Greeter"></cse:rpc-reference>
-
 	<cse:rpc-reference id="server" microservice-name="pojo"
 		schema-id="server" interface="io.servicecomb.demo.server.Test"></cse:rpc-reference>
 		

--- a/providers/provider-pojo/src/test/java/io/servicecomb/provider/pojo/TestInvoker.java
+++ b/providers/provider-pojo/src/test/java/io/servicecomb/provider/pojo/TestInvoker.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.servicecomb.provider.pojo;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.servicecomb.core.CseContext;
+import io.servicecomb.core.definition.MicroserviceMeta;
+import io.servicecomb.core.definition.schema.ConsumerSchemaFactory;
+import io.servicecomb.core.provider.consumer.ConsumerProviderManager;
+import io.servicecomb.core.provider.consumer.ReferenceConfig;
+import io.servicecomb.swagger.engine.SwaggerConsumer;
+import io.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Injectable;
+
+public class TestInvoker {
+    @Test
+    public void testNormalSchemaId(@Injectable ConsumerProviderManager manager,
+            @Injectable ReferenceConfig config,
+            @Injectable MicroserviceMeta microserviceMeta,
+            @Injectable ConsumerSchemaFactory factory) {
+        new Expectations() {
+            {
+                manager.getReferenceConfig("test");
+                result = config;
+                config.getMicroserviceMeta();
+                result = microserviceMeta;
+                microserviceMeta.ensureFindSchemaMeta("schemaId");
+            }
+        };
+        CseContext.getInstance().setConsumerProviderManager(manager);
+        CseContext.getInstance().setConsumerSchemaFactory(factory);
+        CseContext.getInstance().setSwaggerEnvironment(new BootstrapNormal().boot());
+
+        Invoker invoker = new Invoker("test", "schemaId", IPerson.class);
+        invoker.prepare();
+
+        SwaggerConsumer swaggerConsumer = Deencapsulation.getField(invoker, "swaggerConsumer");
+        Assert.assertEquals(IPerson.class, swaggerConsumer.getConsumerIntf());
+    }
+
+    @Test
+    public void testFindSchemaByConsumerInterface(@Injectable ConsumerProviderManager manager,
+            @Injectable ReferenceConfig config,
+            @Injectable MicroserviceMeta microserviceMeta,
+            @Injectable ConsumerSchemaFactory factory) {
+        new Expectations() {
+            {
+                manager.getReferenceConfig("test");
+                result = config;
+                config.getMicroserviceMeta();
+                result = microserviceMeta;
+                microserviceMeta.findSchemaMeta(IPerson.class);
+            }
+        };
+        CseContext.getInstance().setConsumerProviderManager(manager);
+        CseContext.getInstance().setConsumerSchemaFactory(factory);
+        CseContext.getInstance().setSwaggerEnvironment(new BootstrapNormal().boot());
+
+        Invoker invoker = new Invoker("test", null, IPerson.class);
+        invoker.prepare();
+
+        SwaggerConsumer swaggerConsumer = Deencapsulation.getField(invoker, "swaggerConsumer");
+        Assert.assertEquals(IPerson.class, swaggerConsumer.getConsumerIntf());
+    }
+
+    @Test
+    public void testConsumerInterfaceAsSchemaId(@Injectable ConsumerProviderManager manager,
+            @Injectable ReferenceConfig config,
+            @Injectable MicroserviceMeta microserviceMeta,
+            @Injectable ConsumerSchemaFactory factory) {
+        new Expectations() {
+            {
+                manager.getReferenceConfig("test");
+                result = config;
+                config.getMicroserviceMeta();
+                result = microserviceMeta;
+                microserviceMeta.findSchemaMeta(IPerson.class);
+                result = null;
+                microserviceMeta.ensureFindSchemaMeta(IPerson.class.getName());
+            }
+        };
+        CseContext.getInstance().setConsumerProviderManager(manager);
+        CseContext.getInstance().setConsumerSchemaFactory(factory);
+        CseContext.getInstance().setSwaggerEnvironment(new BootstrapNormal().boot());
+
+        Invoker invoker = new Invoker("test", null, IPerson.class);
+        invoker.prepare();
+
+        SwaggerConsumer swaggerConsumer = Deencapsulation.getField(invoker, "swaggerConsumer");
+        Assert.assertEquals(IPerson.class, swaggerConsumer.getConsumerIntf());
+    }
+}

--- a/providers/provider-pojo/src/test/java/io/servicecomb/provider/pojo/reference/PojoReferenceMetaTest.java
+++ b/providers/provider-pojo/src/test/java/io/servicecomb/provider/pojo/reference/PojoReferenceMetaTest.java
@@ -19,73 +19,81 @@ package io.servicecomb.provider.pojo.reference;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import io.servicecomb.core.CseContext;
 import io.servicecomb.core.definition.MicroserviceMeta;
+import io.servicecomb.core.definition.SchemaMeta;
 import io.servicecomb.core.definition.schema.ConsumerSchemaFactory;
 import io.servicecomb.core.provider.consumer.ConsumerProviderManager;
 import io.servicecomb.core.provider.consumer.ReferenceConfig;
+import io.servicecomb.foundation.common.exceptions.ServiceCombException;
 import io.servicecomb.provider.pojo.IPerson;
 import io.servicecomb.swagger.engine.bootstrap.BootstrapNormal;
 import mockit.Expectations;
 import mockit.Injectable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class PojoReferenceMetaTest {
-
-    private PojoReferenceMeta pojoReferenceMeta = new PojoReferenceMeta();
-
-    @Before
-    public void setUp() throws Exception {
+    @Test
+    public void testHasConsumerInterface() {
+        PojoReferenceMeta pojoReferenceMeta = new PojoReferenceMeta();
         pojoReferenceMeta.setMicroserviceName("test");
         pojoReferenceMeta.setSchemaId("schemaId");
         pojoReferenceMeta.setConsumerIntf(IPerson.class);
-    }
 
-    @Test
-    public void testGetSchemaMeta() throws Exception {
-        Assert.assertEquals(null, pojoReferenceMeta.getSchemaMeta());
-    }
+        pojoReferenceMeta.afterPropertiesSet();
 
-    @Test
-    public void testGetObjectType() throws Exception {
         Assert.assertEquals(IPerson.class, pojoReferenceMeta.getObjectType());
-    }
-
-    @Test
-    public void testGetProxy() throws Exception {
-        pojoReferenceMeta.createProxy();
-        assertThat(pojoReferenceMeta.getProxy(), instanceOf(IPerson.class));
-    }
-
-    @Test
-    public void testIsSingleton() throws Exception {
+        Object proxy = pojoReferenceMeta.getProxy();
+        assertThat(proxy, instanceOf(IPerson.class));
         Assert.assertEquals(true, pojoReferenceMeta.isSingleton());
+
+        // not recreate proxy
+        pojoReferenceMeta.createInvoker();
+        Assert.assertSame(proxy, pojoReferenceMeta.getProxy());
     }
 
     @Test
-    public void test(@Injectable ConsumerProviderManager manager,
+    public void testNoConsumerInterface() {
+        PojoReferenceMeta pojoReferenceMeta = new PojoReferenceMeta();
+        pojoReferenceMeta.setMicroserviceName("test");
+        pojoReferenceMeta.setSchemaId("schemaId");
+
+        pojoReferenceMeta.afterPropertiesSet();
+
+        try {
+            pojoReferenceMeta.getProxy();
+            Assert.fail("must throw exception");
+        } catch (ServiceCombException e) {
+            Assert.assertEquals(
+                    "Rpc reference  with service name [test] and schema [schemaId] is not populated",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testNoConsumerInterfaceCreateInvoke(@Injectable ConsumerProviderManager manager,
             @Injectable ReferenceConfig config,
             @Injectable MicroserviceMeta microserviceMeta,
-            @Injectable ConsumerSchemaFactory factory) {
+            @Injectable ConsumerSchemaFactory factory,
+            @Injectable SchemaMeta schemaMeta) {
         new Expectations() {
             {
-                manager.getReferenceConfig("test");
-                result = config;
-                config.getMicroserviceMeta();
-                result = microserviceMeta;
-                microserviceMeta.ensureFindSchemaMeta("schemaId");
+                schemaMeta.getSwaggerIntf();
+                result = IPerson.class;
             }
         };
         CseContext.getInstance().setConsumerProviderManager(manager);
         CseContext.getInstance().setConsumerSchemaFactory(factory);
         CseContext.getInstance().setSwaggerEnvironment(new BootstrapNormal().boot());
 
-        Assert.assertEquals(null, pojoReferenceMeta.getReferenceConfig());
-        Assert.assertEquals(IPerson.class, pojoReferenceMeta.getConsumerIntf());
-        pojoReferenceMeta.createInvoker();
+        PojoReferenceMeta pojoReferenceMeta = new PojoReferenceMeta();
+        pojoReferenceMeta.setMicroserviceName("test");
+        pojoReferenceMeta.setSchemaId("schemaId");
         pojoReferenceMeta.afterPropertiesSet();
-        Assert.assertEquals(config, pojoReferenceMeta.getReferenceConfig());
+
+        pojoReferenceMeta.createInvoker();
+        assertThat(pojoReferenceMeta.getProxy(), instanceOf(IPerson.class));
     }
 }

--- a/providers/provider-rest-common/src/main/java/io/servicecomb/provider/rest/common/RestConsumerProvider.java
+++ b/providers/provider-rest-common/src/main/java/io/servicecomb/provider/rest/common/RestConsumerProvider.java
@@ -27,8 +27,4 @@ public class RestConsumerProvider extends AbstractConsumerProvider {
     public String getName() {
         return RestConst.REST;
     }
-
-    @Override
-    public void init() throws Exception {
-    }
 }

--- a/transports/transport-highway/src/main/java/io/servicecomb/transport/highway/HighwayClientConnection.java
+++ b/transports/transport-highway/src/main/java/io/servicecomb/transport/highway/HighwayClientConnection.java
@@ -18,8 +18,6 @@ package io.servicecomb.transport.highway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.protostuff.LinkedBuffer;
-import io.protostuff.ProtobufOutput;
 import io.protostuff.runtime.ProtobufFeature;
 import io.servicecomb.foundation.vertx.client.tcp.AbstractTcpClientPackage;
 import io.servicecomb.foundation.vertx.client.tcp.TcpClientConfig;
@@ -50,17 +48,12 @@ public class HighwayClientConnection extends TcpClientConnection {
     @Override
     protected TcpOutputStream createLogin() {
         try {
-            LinkedBuffer linkedBuffer = LinkedBuffer.allocate();
-            ProtobufOutput output = new ProtobufOutput(linkedBuffer);
-
             RequestHeader header = new RequestHeader();
             header.setMsgType(MsgType.LOGIN);
-            header.writeObject(output);
 
             LoginRequest login = new LoginRequest();
             login.setProtocol(HighwayTransport.NAME);
             login.setUseProtobufMapCodec(true);
-            login.writeObject(output);
 
             HighwayOutputStream os = new HighwayOutputStream(AbstractTcpClientPackage.getAndIncRequestId(), null);
             os.write(header, LoginRequest.getLoginRequestSchema(), login);


### PR DESCRIPTION
this is only a simple modify, still remain old complex logic
if we can remove usage of below, consumer init will be very simple.
`
<cse:rpc-reference id="..." microservice-name="..." schema-id="..."/>
`

only rpc-reference in xml and missed interface property will block boot and query schema from SC.